### PR TITLE
Add getIdFromClassName method to Tab class and refactor TabManager

### DIFF
--- a/.github/workflows/phpstan-stubs.php
+++ b/.github/workflows/phpstan-stubs.php
@@ -189,6 +189,12 @@ class Tab
     {
         return true;
     }
+
+    /** @return int|false */
+    public static function getIdFromClassName($className)
+    {
+       return 0;
+    }
 }
 
 /** @return string */

--- a/Tab/TabManager.php
+++ b/Tab/TabManager.php
@@ -79,11 +79,6 @@ class TabManager implements TabManagerInterface
 
     public function getIdByControllerClassName($controllerClassName): int
     {
-        /**
-         * @var TabRepository $tabRepository
-         */
-        $tabRepository = $this->module->get('prestashop.core.admin.tab.repository');
-
-        return (int) $tabRepository->findOneIdByClassName($controllerClassName);
+        return (int) \Tab::getIdFromClassName($controllerClassName);
     }
 }


### PR DESCRIPTION
- Introduced a new static method `getIdFromClassName` in the Tab class to retrieve an ID based on the class name.
- Refactored the `getIdByControllerClassName` method in TabManager to utilize the new method for improved code clarity and maintainability.